### PR TITLE
Add prerelease handler on Get and Install verbs

### DIFF
--- a/src/Foil.ps1
+++ b/src/Foil.ps1
@@ -181,6 +181,12 @@ $Commands = @(
                         OriginalName = '--force'
                         ParameterType = 'switch'
                         Description = 'Force the operation'
+                    },
+                    @{
+                        Name = 'PreRelease'
+                        OriginalName = '--pre'
+                        ParameterType = 'switch'
+                        Description = 'Include prerelease packages'
                     }
                 )
             },
@@ -213,6 +219,12 @@ $Commands = @(
                         ParameterType = 'string'
                         Description = 'Package Source'
                         NoGap = $true
+                    },
+                    @{
+                        Name = 'PreRelease'
+                        OriginalName = '--pre'
+                        ParameterType = 'switch'
+                        Description = 'Include prerelease packages'
                     }
                 )
                 OutputHandlers = @{

--- a/test/Foil.tests.ps1
+++ b/test/Foil.tests.ps1
@@ -61,6 +61,24 @@ Describe "DSC-compliant package installation and uninstallation" {
 			Uninstall-ChocoPackage -Name $package | Where-Object {$_.Name -contains $package} | Should -Not -BeNullOrEmpty
 		}
 	}
+	Context 'with prerelease parameter' {
+		BeforeAll {
+			$package = 'firefox-dev'
+		}
+
+		It 'searches for the latest version of a package' {
+			Get-ChocoPackage -Name $package -PreRelease | Where-Object {$_.Name -contains $package} | Should -Not -BeNullOrEmpty
+		}
+		It 'silently installs the latest version of a package' {
+			Install-ChocoPackage -Name $package -PreRelease -Force | Where-Object {$_.Name -contains $package} | Should -Not -BeNullOrEmpty
+		}
+		It 'finds the locally installed package just installed' {
+			Get-ChocoPackage -Name $package -LocalOnly | Where-Object {$_.Name -contains $package} | Should -Not -BeNullOrEmpty
+		}
+		It 'silently uninstalls the locally installed package just installed' {
+			Uninstall-ChocoPackage -Name $package | Where-Object {$_.Name -contains $package} | Should -Not -BeNullOrEmpty
+		}
+	}
 }
 
 Describe "pipline-based package installation and uninstallation" {
@@ -110,6 +128,18 @@ Describe "pipline-based package installation and uninstallation" {
 		}
 		It 'correctly passed parameters to the package' {
 			Get-ChildItem -Path (Join-Path -Path $env:ProgramFiles -ChildPath $package) -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+		}
+		It 'finds and silently uninstalls the locally installed package just installed' {
+			Get-ChocoPackage -Name $package -LocalOnly -Exact | Uninstall-ChocoPackage | Where-Object {$_.Name -contains $package} | Should -Not -BeNullOrEmpty
+		}
+	}
+	Context 'with prerelease parameter' {
+		BeforeAll {
+			$package = 'firefox-dev'
+		}
+
+		It 'searches for and silently installs the latest version of a package' {
+			Get-ChocoPackage -Name $package -PreRelease | Install-ChocoPackage -Force | Where-Object {$_.Name -contains $package} | Should -Not -BeNullOrEmpty
 		}
 		It 'finds and silently uninstalls the locally installed package just installed' {
 			Get-ChocoPackage -Name $package -LocalOnly -Exact | Uninstall-ChocoPackage | Where-Object {$_.Name -contains $package} | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
I had a need to work with `--pre` to handle Firefox Developer packages, so extended this module to include that parameter. It was tested locally to both get and install the above package.