### PR TITLE
Add user/password params to Register-ChocoSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-11-17
+#### Added
+* Optional `-User` and `-Password` parameters to `Register-ChocoSource`
+
 ## [0.3.0] - 2023-01-21
 #### Added
 * Futureproofing support for Chocolatey v2.0.0 and higher

--- a/src/Foil.ps1
+++ b/src/Foil.ps1
@@ -74,6 +74,22 @@ $Commands = @(
                         ParameterType = 'string'
                         Description = 'Source Location'
                         Mandatory = $true
+                    },
+                    @{
+                        Name = 'User'
+                        OriginalName = '--user='
+                        NoGap = $true
+                        ParameterType = 'string'
+                        Description = 'User Name'
+                        Mandatory = $false
+                    },
+                    @{
+                        Name = 'Password'
+                        OriginalName = '--password='
+                        NoGap = $true
+                        ParameterType = 'string'
+                        Description = 'User Password'
+                        Mandatory = $false
                     }
                 )
             },

--- a/src/Foil.psd1
+++ b/src/Foil.psd1
@@ -1,6 +1,6 @@
 @{
 	RootModule = 'Foil.psm1'
-	ModuleVersion = '0.3.0'
+	ModuleVersion = '0.3.1'
 	GUID = '38430603-9954-45fd-949a-5f79492ffaf7'
 	Author = 'Ethan Bergstrom'
 	Copyright = '2021-2023'


### PR DESCRIPTION
Added Optional `-User` and `-Password` parameters to `Register-ChocoSource` to enable authentication to private repositories, such as Azure Artifacts.